### PR TITLE
Remove opt-in code from operator scheme

### DIFF
--- a/CodeSchemes/somalia_operator.json
+++ b/CodeSchemes/somalia_operator.json
@@ -1,7 +1,7 @@
 {
   "SchemeID": "Scheme-f86cff0b",
   "Name": "Somalia Operator",
-  "Version": "0.0.0.2",
+  "Version": "0.0.1.0",
   "Codes": [
     {
       "CodeID": "code-450ec146",
@@ -85,15 +85,6 @@
       "DisplayText": "NC (not coded)",
       "NumericValue": -30,
       "StringValue": "NC",
-      "VisibleInCoda": true
-    },
-    {
-      "CodeID": "code-OI-c5f1d054",
-      "CodeType": "Meta",
-      "MetaCode": "opt-in",
-      "DisplayText": "opt-in",
-      "NumericValue": -100040,
-      "StringValue": "opt_in",
       "VisibleInCoda": true
     },
     {


### PR DESCRIPTION
This scheme doesn't get applied to manually labelled free-text, so it doesn't make sense to have this code on this scheme.

(adding both reviewers simultaneously because this is a duplicate of https://github.com/AfricasVoices/Project-WorldBank-PLR/pull/31)